### PR TITLE
feat: add footer osgeo logo (refs #5)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,7 +90,13 @@ const config = {
         ],
       },
       footer: {
-        style: 'dark',
+        style: 'light',
+        logo: {
+          alt: 'OSGeo Logo',
+          src: 'img/logo-osgeo.svg',
+          href: 'https://www.osgeo.org/projects/geostyler/',
+          height: 40,
+        },
         links: [
           {
             title: 'More',


### PR DESCRIPTION
Adds a logo in the theme footer configuration, with link to the GeoStyler project page on the OSGeo website.

![image](https://github.com/user-attachments/assets/82b798e1-72e8-4666-a550-e0e108303f6b)

Related issue : #5 
